### PR TITLE
[chores] gitignore updated to include data used in test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Datasets
 
 src/data/*
+src/transformers/__tests__/test_data/AClassicEducation_NightOwl
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
Quick update to gitignore to ignore the data used in a test so that it's not pushed to github. 

This gitignore statement can be made more generic later (i.e. to include test_data/*) if necessary. I'm not yet sure about the folder structure of where I want to store my tests, so this will suffice for now.